### PR TITLE
chore(package): use >= for webpack peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "webpack": "^2.2.1"
   },
   "peerDependencies": {
-    "webpack": "^2.2.1"
+    "webpack": ">=2.2.1"
   },
   "jest": {
     "notify": true,


### PR DESCRIPTION
Hello,

thanks for this plugin.
As webpack is already past version 3, and still compatible with this package I updated the peerDependency definition to include that.
To future proof this setting I used an opened ended >= range.

This gets rid of an npm warning

> npm WARN webpack2-sentry-plugin@2.0.4 requires a peer of webpack@^2.2.1 but none is installed. You must install peer dependencies yourself.

Thanks for considering,

Stephan